### PR TITLE
R-I-84 Para usuarios no autenticados limitar a 2000 la información presentable (HTML, JSON o XML). Cuando supere este límite deben generar mensaje de error como "La consulta pública permite máximo 2000 registros. Puede suscribirse a SIVeL Pro si requiere más". El mapa debería presentar el error si le ocurre

### DIFF
--- a/app/views/sivel2_gen/casos/index.html.erb
+++ b/app/views/sivel2_gen/casos/index.html.erb
@@ -49,7 +49,18 @@
 <% end %>
 
 <div id="casos">
-  <%= render 'index_tabla' %>
+  <%if current_usuario %>
+    <%= render 'index_tabla' %>
+  <% else %>
+    <% if @conscaso.count <= 2000 %>
+      <%= render 'index_tabla' %>
+    <% else %>
+      <div class="alert alert-danger">
+        <h4><strong>La consulta pública permite máximo 2000 registros. Puede suscribirse a SIVeL Pro si requiere más</strong></h4>
+        <p>Puede usar el filtro de búsqueda avanzada para obtener menos registros</p>
+      </div>
+    <% end %>
+  <% end %>
 </div>
 
 <%= link_to t('.new', :default => t("helpers.links.new")),

--- a/lib/sivel2_gen/concerns/controllers/casos_controller.rb
+++ b/lib/sivel2_gen/concerns/controllers/casos_controller.rb
@@ -261,50 +261,89 @@ module Sivel2Gen
             @registros = @consexpcaso
             programa_generacion_listado(params, formato, :caso_id)
           end
-
+          
+          def error_plantilla_no_autenticado
+            redirect_back fallback_location: 
+            config.relative_url_root,
+            flash: { error: "La generación de este reporte permite máximo 2000 registros. Puede suscribirse a SIVeL Pro si requiere más" }
+          end
 
           def presenta_index
             # Presentación
             respond_to do |format|
-              format.ods { 
-                gen_formato('.ods')
-                return 
-              }
-              if request.format.symbol == 'ods'.to_sym
-                # No funciona el anterior
-                gen_formato('.ods')
-                return
-              end
-              format.html { 
-                if (params['idplantilla']) 
-                  #byebug
-                  case params['idplantilla']
-                  when 'reprevista'
-                    render params['idplantilla'], layout: nil
-                  else
-                    redirect_back fallback_location: 
-                      config.relative_url_root,
-                      flash: { error: "Plantilla desconocida" }
-                  end
-                else
-                  render layout: 'application' 
+              if @conscaso.count <= 2000 || current_usuario
+                format.ods { 
+                  gen_formato('.ods')
+                  return 
+                }
+                if request.format.symbol == 'ods'.to_sym
+                  # No funciona el anterior
+                  gen_formato('.ods')
+                  return
                 end
-                return
-              }
+                format.html { 
+                  if (params['idplantilla']) 
+                    #byebug
+                    case params['idplantilla']
+                    when 'reprevista'
+                      render params['idplantilla'], layout: nil
+                    else
+                      redirect_back fallback_location: 
+                        config.relative_url_root,
+                        flash: { error: "Plantilla desconocida" }
+                    end
+                  else
+                    render layout: 'application' 
+                  end
+                  return
+                }
 
-              format.js { 
-                render 'sivel2_gen/casos/filtro'
-                return
-              }
+                format.js { 
+                  render 'sivel2_gen/casos/filtro'
+                  return
+                }
 
-              format.json {
-                render 'reprevista.json'
-                return
-              }
-              format.xrlat {
-                render 'reprevista.xrlat'
-                return
-              }
+                format.json {
+                  render 'reprevista.json'
+                  return
+                }
+
+                format.xrlat {
+                  render 'reprevista.xrlat'
+                  return
+                }
+              else
+                format.html { 
+                  if (params['idplantilla']) 
+                    case params['idplantilla']
+                    when 'reprevista'
+                      error_plantilla_no_autenticado
+                    end
+                  else
+                    render layout: 'application' 
+                  end
+                  return
+                }
+
+                format.ods { 
+                  error_plantilla_no_autenticado
+                  return
+                }
+
+                format.js { 
+                  error_plantilla_no_autenticado
+                  return
+                }
+
+                format.json {
+                  error_plantilla_no_autenticado
+                  return
+                }
+                format.xrlat {
+                  error_plantilla_no_autenticado
+                  return
+                }
+              end
             end
           end
 

--- a/lib/sivel2_gen/concerns/controllers/casos_controller.rb
+++ b/lib/sivel2_gen/concerns/controllers/casos_controller.rb
@@ -272,17 +272,17 @@ module Sivel2Gen
             # Presentación
             respond_to do |format|
               if @conscaso.count <= 2000 || current_usuario
-                format.ods { 
+                format.ods {
                   gen_formato('.ods')
-                  return 
+                  return
                 }
                 if request.format.symbol == 'ods'.to_sym
                   # No funciona el anterior
                   gen_formato('.ods')
                   return
                 end
-                format.html { 
-                  if (params['idplantilla']) 
+                format.html {
+                  if (params['idplantilla'])
                     #byebug
                     case params['idplantilla']
                     when 'reprevista'
@@ -293,12 +293,12 @@ module Sivel2Gen
                         flash: { error: "Plantilla desconocida" }
                     end
                   else
-                    render layout: 'application' 
+                    render layout: 'application'
                   end
                   return
                 }
 
-                format.js { 
+                format.js {
                   render 'sivel2_gen/casos/filtro'
                   return
                 }
@@ -313,24 +313,24 @@ module Sivel2Gen
                   return
                 }
               else
-                format.html { 
+                format.html {
                   if (params['idplantilla']) 
                     case params['idplantilla']
                     when 'reprevista'
                       error_plantilla_no_autenticado
                     end
                   else
-                    render layout: 'application' 
+                    render layout: 'application'
                   end
                   return
                 }
 
-                format.ods { 
+                format.ods {
                   error_plantilla_no_autenticado
                   return
                 }
 
-                format.js { 
+                format.js {
                   error_plantilla_no_autenticado
                   return
                 }

--- a/lib/sivel2_gen/concerns/controllers/casos_controller.rb
+++ b/lib/sivel2_gen/concerns/controllers/casos_controller.rb
@@ -261,11 +261,12 @@ module Sivel2Gen
             @registros = @consexpcaso
             programa_generacion_listado(params, formato, :caso_id)
           end
-          
+
           def error_plantilla_no_autenticado
-            redirect_back fallback_location: 
-            config.relative_url_root,
-            flash: { error: "La generación de este reporte permite máximo 2000 registros. Puede suscribirse a SIVeL Pro si requiere más" }
+            redirect_back fallback_location: config.relative_url_root,
+            flash: { error: 
+            'La generación de este reporte permite máximo 2000 registros.' +
+            ' Puede suscribirse a SIVeL Pro si requiere más' }
           end
 
           def presenta_index


### PR DESCRIPTION
Para la tabla principal de casos index:  Si no está autenticado y el total de casos es mayor que 2000, entonces en lugar de renderizar la tabla, mostrará el mensaje de error. (en este mensaje también se invita a hacer uso del filtro para obtener menos registros)
Para el reporte de revistas xml, json ods y html: SI no está autenticado y es mayor que 2000 . No genera el reporta y re direcciona al index actual. 
Con respecto al mapa, no se ha implementado ninguna restricción ya que el mapa solo está disponibles para usuarios autenticados.