### PR TITLE
R-I-84 Para usuarios no autenticados limitar a 2000 la información presentable (HTML, JSON o XML). Cuando supere este límite deben generar mensaje de error como "La consulta pública permite máximo 2000 registros. Puede suscribirse a SIVeL Pro si requiere más". El mapa debería presentar el error si le ocurre

### DIFF
--- a/app/views/sivel2_gen/casos/filtro.js.erb
+++ b/app/views/sivel2_gen/casos/filtro.js.erb
@@ -1,2 +1,10 @@
 $("#numconscaso").html("<%= @numconscaso %>");
-$("#casos").html("<%= escape_javascript(render('sivel2_gen/casos/index_tabla')) %>");
+<%if @numconscaso <= 2000 || current_usuario %>
+    $("#casos").html("<%= escape_javascript(render('sivel2_gen/casos/index_tabla')) %>")
+<% else %>
+    $("#casos").html('<div id="" class="alert alert-danger">'+
+      '<h4><strong>La consulta pública permite máximo 2000 registros.'+
+      ' Puede suscribirse a SIVeL Pro si requiere más</strong></h4>'+
+      ' <p>Puede usar el filtro de búsqueda avanzada para obteneri'+
+      ' menos registros</p></div>')
+<% end %>

--- a/lib/sivel2_gen/concerns/controllers/casos_controller.rb
+++ b/lib/sivel2_gen/concerns/controllers/casos_controller.rb
@@ -339,7 +339,7 @@ module Sivel2Gen
                 }
 
                 format.js {
-                  error_plantilla_no_autenticado
+                  render 'sivel2_gen/casos/filtro'
                   return
                 }
 


### PR DESCRIPTION
Arreglo de problema encontrado con filtros