### PR TITLE
F-351 arregla principal ubicacion en vista

### DIFF
--- a/app/assets/javascripts/sivel2_gen/motor.js.coffee
+++ b/app/assets/javascripts/sivel2_gen/motor.js.coffee
@@ -557,6 +557,15 @@ enviaFormularioContar= (root) ->
     ubipais = 'select[id^=caso_][id$=id_pais]'
     $(ubipais).val(170).trigger('chosen:updated')
     llena_departamento($(ubicacion.find(ubipais)), root)
+    if $(".ubicacion:visible").length == 1
+      principal = $('input[type="checkbox"][name$="[principal]"]:visible')
+      principal.prop('checked', true)
+  )
+
+  $('#ubicaciones').on('cocoon:after-remove', '', (e, ubicacion) ->
+    if $('input[type="checkbox"][name$="[principal]"]:visible:checkbox:checked').length == 0
+      ubis = $('input[type="checkbox"][name$="[principal]"]:visible')
+      $(ubis[0]).prop('checked', true)
   )
 
   # En victimas permite autocompletar nombres de victima

--- a/app/views/sivel2_gen/casos/_ubicacion_fields.html.erb
+++ b/app/views/sivel2_gen/casos/_ubicacion_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='control-group nested-fields'>
+<div class='control-group nested-fields ubicacion'>
   <div class="controls">
 
     <div class="row">


### PR DESCRIPTION
Al insertar una ubicación, la primera tiene principal marcada por omisión.
Además otra validación: En caso de que se elimine una ubicación en la lista la cual estaba marcada como principal, automáticamente, la primera ubicación pasaría a ser la principal (esto con el fin de que en ningún momento quede sin una ubicación principal entre las que hay).