### PR TITLE
R494 Desagrega Categoria y Departamento y F495

### DIFF
--- a/app/assets/javascripts/sivel2_gen/motor.js.coffee
+++ b/app/assets/javascripts/sivel2_gen/motor.js.coffee
@@ -1049,3 +1049,29 @@ enviaFormularioContarPost= (root) ->
 
   @sip_registra_cambios_para_bitacora(root)
   return
+
+
+$(document).on('change', '#filtro_desagregar', (e) ->
+  valor = this.value
+  if valor == 'Departamento'
+    fil_dep = $("#filtro_departamentos")
+    fil_sex = $("#filtro_sexo")
+    fil_cat = $("#filtro_categorias")
+    fil_dep.parent().css('display', 'none')
+    fil_sex.parent().css('display', 'block')
+    fil_cat.parent().css('display', 'block')
+  if valor == 'Categoria'
+    fil_cat = $("#filtro_categorias")
+    fil_dep = $("#filtro_departamentos")
+    fil_sex = $("#filtro_sexo")
+    fil_cat.parent().css('display', 'none')
+    fil_dep.parent().css('display', 'block')
+    fil_sex.parent().css('display', 'block')
+  if valor == 'Sexo'
+    fil_cat = $("#filtro_categorias")
+    fil_dep = $("#filtro_departamentos")
+    fil_sex = $("#filtro_sexo")
+    fil_sex.parent().css('display', 'none')
+    fil_dep.parent().css('display', 'block')
+    fil_cat.parent().css('display', 'block')
+)

--- a/app/controllers/sivel2_gen/fil23_gen/graficar_apexcharts_controller.rb
+++ b/app/controllers/sivel2_gen/fil23_gen/graficar_apexcharts_controller.rb
@@ -5,9 +5,11 @@ module Sivel2Gen
     class GraficarApexchartsController < ApplicationController
 
       # Control de acceso no estandar en función
-      
+
       def victimizaciones_individuales
         authorize! :contar, Sivel2Gen::Caso
+
+        ## Valores de los filtros
         @vic_fechaini = params[:filtro] ? Sip::FormatoFechaHelper.fecha_local_estandar(params[:filtro][:fechaini]) : "1998-01-01"
         @vic_fechafin = params[:filtro] ? Sip::FormatoFechaHelper.fecha_local_estandar(params[:filtro][:fechafin]) : "2020-12-31"
 
@@ -19,7 +21,10 @@ module Sivel2Gen
               AND sivel2_gen_categoria.tipocat=\'I\'').
               reorder('sivel2_gen_supracategoria.id_tviolencia', :id).pluck(:nombre).uniq 
         @vic_categorias = params[:filtro] ? params[:filtro][:categorias] : @categorias
-        def consulta(sexo)
+        filtro_sexo = params[:filtro] ? params[:filtro][:sexo] : Sip::Persona::SEXO_OPCIONES.map{|se| se[1].to_s}
+        @vic_sexo = filtro_sexo == "" ? ["S", "M", "H"] : filtro_sexo
+        ## Consulta para desagregar por Sexo
+        def consulta_sexo(sexo)
           "select caso.fecha as fecha_caso, count(*) as total from cvt1 JOIN sivel2_gen_caso as caso ON caso.id=id_caso 
           JOIN sip_persona AS persona ON persona.id=id_persona
           JOIN sip_ubicacion as ubi ON ubi.id=caso.ubicacion_id
@@ -31,17 +36,56 @@ module Sivel2Gen
           AND categoria.nombre IN (" + (@vic_categorias - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
           GROUP BY fecha_caso ORDER BY fecha_caso;"
         end
+
+        ## Consulta para desagregar por Departamento
+        def consulta_dep(dep_id)
+          "select caso.fecha as fecha_caso, count(*) as total from cvt1 JOIN sivel2_gen_caso as caso ON caso.id=id_caso 
+          JOIN sip_persona AS persona ON persona.id=id_persona
+          JOIN sip_ubicacion as ubi ON ubi.id=caso.ubicacion_id
+          JOIN sivel2_gen_categoria AS categoria ON categoria.id=id_categoria
+          WHERE ubi.id_departamento ='#{dep_id}' 
+          AND caso.fecha >='" + @vic_fechaini + "'
+          AND caso.fecha <='" + @vic_fechafin + "'
+          AND persona.sexo IN (" + (@vic_sexo - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
+          AND categoria.nombre IN (" + (@vic_categorias - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
+          GROUP BY fecha_caso ORDER BY fecha_caso;"
+        end
         def consulta_totsex
           "select persona.sexo as sexo_persona, count(*) as total from cvt1
           JOIN sip_persona AS persona ON persona.id=id_persona 
           GROUP BY sexo_persona 
           ORDER BY persona.sexo='S', persona.sexo='M', persona.sexo='F';"
         end
-        @valores_m = ActiveRecord::Base.connection.execute(consulta('M')).values.to_h 
-        @valores_f = ActiveRecord::Base.connection.execute(consulta('F')).values.to_h 
-        @valores_s = ActiveRecord::Base.connection.execute(consulta('S')).values.to_h 
-        @valores_totsex = ActiveRecord::Base.connection.execute(consulta_totsex).values.to_h 
-        render 'fil23_gen/graficar_apexcharts/victimizaciones_individuales', 
+        valores_m = ActiveRecord::Base.connection.execute(consulta_sexo('M')).values.to_h 
+        valores_f = ActiveRecord::Base.connection.execute(consulta_sexo('F')).values.to_h 
+        valores_s = ActiveRecord::Base.connection.execute(consulta_sexo('S')).values.to_h 
+        @valores_totsex = ActiveRecord::Base.connection.execute(consulta_totsex).values.to_h
+
+        if params[:filtro]
+          if params[:filtro][:desagregar] == 'Sexo' 
+              series_gen= [
+                {name: "Hombres",
+                 data: valores_m},
+                {name: "Mujeres",
+                 data: valores_f},
+                {name: "Sin sexo",
+                 data: valores_s}
+              ]
+          end
+          if params[:filtro][:desagregar] == 'Departamento' 
+            series_gen= []
+            deps = Sip::Departamento.habilitados
+            deps.each do |dep|
+              valores_dep = ActiveRecord::Base.connection.execute(consulta_dep(dep.id)).values.to_h 
+              predep = {name: dep.nombre, data: valores_dep}
+              series_gen.push(predep)
+            end
+          end
+        else 
+          series_gen= []
+        end
+
+        render 'fil23_gen/graficar_apexcharts/victimizaciones_individuales', locals: {series_gen: series_gen},  
           layout: 'application'
       end
     end

--- a/app/controllers/sivel2_gen/fil23_gen/graficar_apexcharts_controller.rb
+++ b/app/controllers/sivel2_gen/fil23_gen/graficar_apexcharts_controller.rb
@@ -37,53 +37,115 @@ module Sivel2Gen
           GROUP BY fecha_caso ORDER BY fecha_caso;"
         end
 
-        ## Consulta para desagregar por Departamento
-        def consulta_dep(dep_id)
-          "select caso.fecha as fecha_caso, count(*) as total from cvt1 JOIN sivel2_gen_caso as caso ON caso.id=id_caso 
+        def consulta_gen(desagregado, filtros)
+          "select caso.fecha as fecha_caso, count(*) as total from cvt1 
+          JOIN sivel2_gen_caso as caso ON caso.id=id_caso 
           JOIN sip_persona AS persona ON persona.id=id_persona
           JOIN sip_ubicacion as ubi ON ubi.id=caso.ubicacion_id
           JOIN sivel2_gen_categoria AS categoria ON categoria.id=id_categoria
-          WHERE ubi.id_departamento ='#{dep_id}' 
+          WHERE #{desagregado} 
           AND caso.fecha >='" + @vic_fechaini + "'
           AND caso.fecha <='" + @vic_fechafin + "'
-          AND persona.sexo IN (" + (@vic_sexo - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
-          AND categoria.nombre IN (" + (@vic_categorias - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
+          #{filtros} 
           GROUP BY fecha_caso ORDER BY fecha_caso;"
         end
+
         def consulta_totsex
           "select persona.sexo as sexo_persona, count(*) as total from cvt1
           JOIN sip_persona AS persona ON persona.id=id_persona 
           GROUP BY sexo_persona 
           ORDER BY persona.sexo='S', persona.sexo='M', persona.sexo='F';"
         end
-        valores_m = ActiveRecord::Base.connection.execute(consulta_sexo('M')).values.to_h 
-        valores_f = ActiveRecord::Base.connection.execute(consulta_sexo('F')).values.to_h 
-        valores_s = ActiveRecord::Base.connection.execute(consulta_sexo('S')).values.to_h 
-        @valores_totsex = ActiveRecord::Base.connection.execute(consulta_totsex).values.to_h
+
+        def consulta_totcat
+          "select categoria.nombre as categoria_nom, count(*) as total from cvt1
+          JOIN sivel2_gen_categoria AS categoria ON categoria.id=id_categoria
+          GROUP BY categoria_nom;"
+        end
+
+        def consulta_totdep
+          "select departamento.nombre as departamento_nombre, count(*) as total from cvt1
+          JOIN sivel2_gen_caso as caso ON caso.id=id_caso 
+          JOIN sip_ubicacion as ubi ON ubi.id=caso.ubicacion_id
+          JOIN sip_departamento as departamento ON departamento.id=ubi.id_departamento
+          GROUP BY departamento_nombre;"
+        end
+
+        def graficar_sexo
+          series_gen= []
+          Sip::Persona::SEXO_OPCIONES.each do |sexo|
+            desagr = "persona.sexo ='#{sexo[1].to_s}'" 
+            filtros= "
+            AND ubi.id_departamento IN (#{(@vic_dep - ['']).join(', ')})
+            AND categoria.nombre IN (" + (@vic_categorias - ['']).map{|k| "'" + k + "'"}.join(', ') + ")" 
+            valores_sex = ActiveRecord::Base.connection.execute(consulta_gen(desagr, filtros)).values.to_h 
+            presex = {name: sexo[0], data: valores_sex}
+            series_gen.push(presex)
+          end
+          return series_gen
+        end 
 
         if params[:filtro]
           if params[:filtro][:desagregar] == 'Sexo' 
-              series_gen= [
-                {name: "Hombres",
-                 data: valores_m},
-                {name: "Mujeres",
-                 data: valores_f},
-                {name: "Sin sexo",
-                 data: valores_s}
-              ]
+            series_gen = graficar_sexo
+            sexos = Sip::Persona::SEXO_OPCIONES.to_h.invert
+            valores = ActiveRecord::Base.connection.execute(consulta_totsex).values.to_h
+            @valores_tot= valores.to_a.map{|k| [sexos[k[0].to_sym], k[1]]}.to_h 
+            @opciones_tot = {
+              titulo: 'Victimizaciones por sexo',
+              ejex: 'Sexo',
+              ejey: 'Victimizaciones'
+            }
           end
           if params[:filtro][:desagregar] == 'Departamento' 
             series_gen= []
             deps = Sip::Departamento.habilitados
             deps.each do |dep|
-              valores_dep = ActiveRecord::Base.connection.execute(consulta_dep(dep.id)).values.to_h 
+              desagr = "ubi.id_departamento ='#{dep.id}'" 
+              filtros= "AND persona.sexo IN (" + (@vic_sexo - ['']).map{|k| "'" + k + "'"}.join(', ') + ")
+          AND categoria.nombre IN (" + (@vic_categorias - ['']).map{|k| "'" + k + "'"}.join(', ') + ")"
+              valores_dep = ActiveRecord::Base.connection.execute(consulta_gen(desagr, filtros)).values.to_h 
               predep = {name: dep.nombre, data: valores_dep}
               series_gen.push(predep)
             end
+            @valores_tot = ActiveRecord::Base.connection.execute(consulta_totdep).values.to_h
+            @opciones_tot = {
+              titulo: 'Victimizaciones por departamento',
+              ejex: 'Departamentos',
+              ejey: 'Victimizaciones'
+            }
+          end
+
+          if params[:filtro][:desagregar] == 'Categoria' 
+            series_gen= []
+            @categorias.each do |cat|
+              desagr = "categoria.nombre ='#{cat}'"
+              filtros= "
+              AND ubi.id_departamento IN (#{(@vic_dep - ['']).join(', ')})
+              AND persona.sexo IN (" + (@vic_sexo - ['']).map{|k| "'" + k + "'"}.join(', ') + ')'"" 
+              valores_cat = ActiveRecord::Base.connection.execute(consulta_gen(desagr, filtros)).values.to_h 
+              precat = {name: cat, data: valores_cat}
+              series_gen.push(precat)
+            end
+            @valores_tot = ActiveRecord::Base.connection.execute(consulta_totcat).values.to_h
+            @opciones_tot = {
+              titulo: 'Victimizaciones por Categorías de violencia',
+              ejex: 'Categorías de violencia',
+              ejey: 'Victimizaciones'
+            }
           end
         else 
-          series_gen= []
+          series_gen = graficar_sexo
+          sexos = Sip::Persona::SEXO_OPCIONES.to_h.invert
+          valores = ActiveRecord::Base.connection.execute(consulta_totsex).values.to_h
+          @valores_tot= valores.to_a.map{|k| [sexos[k[0].to_sym], k[1]]}.to_h 
+          @opciones_tot = {
+            titulo: 'Victimizaciones por sexo',
+            ejex: 'Sexo',
+            ejey: 'Victimizaciones'
+          }
         end
+
 
         render 'fil23_gen/graficar_apexcharts/victimizaciones_individuales', locals: {series_gen: series_gen},  
           layout: 'application'

--- a/app/views/fil23_gen/graficar_apexcharts/victimizaciones_individuales.html.erb
+++ b/app/views/fil23_gen/graficar_apexcharts/victimizaciones_individuales.html.erb
@@ -7,22 +7,23 @@
    stacked: true 
   }
 
-  series_totsex= [
-    {name: "Hombres",
-     data: @valores_totsex}
+  series_tot= [
+    {name: "Victimizaciones",
+     data: @valores_tot}
   ]
 
-  opciones_totsex = {
-   title: 'Totales por sexo',
-   xtitle: 'Sexo',
-   ytitle: 'Victimizaciones'
+  opciones_tot = {
+   title: @opciones_tot[:titulo],
+   xtitle: @opciones_tot[:ejex],
+   ytitle: @opciones_tot[:ejey],
+   data_labels: false
   }
 %>
 
 <%= simple_form_for :filtro do |f| %>
 <div class="card" >
   <div class="card-header">
-    <h3> Filtrar por: </h3>
+    <h5> Filtros y Desagregación</h5>
   </div>
   <div class="card-body">
     <div class="row">
@@ -62,21 +63,33 @@
           } %>
       </div>
       <div class="offset-sm-0 col-3">
-        <%= f.input :sexo,
-          collection: Sip::Persona::SEXO_OPCIONES, 
-          label: 'Sexo:',
-          include_blank: '--Mostrar Todos',
+        <% if params.nil? || params[:filtro].nil? || params[:filtro][:desagregar].nil?
+             ops= 'Sexo' 
+           else
+             ops= params[:filtro][:desagregar]
+           end %>
+        <%= f.input :desagregar,
+          collection: ['Sexo', 'Departamento', 'Categoria'], 
+          label: 'Desagregar por:',
+          selected: ops,
           input_html: {
             'data-enviarautomatico' => ''}
          %>
       </div>
       <div class="offset-sm-0 col-3">
-        <%= f.input :desagregar,
-          collection: ['Sexo', 'Departamento', 'Categoria'], 
-          label: 'Desagregar por:',
-          selected: 'Categoria',
+        <% if params.nil? || params[:filtro].nil? || params[:filtro][:desagregar].nil? || params[:filtro][:desagregar]== 'Sexo'
+ %>
+          <% estdes = "display: none" %>
+        <% else %>
+          <% estdes = "display: block" %>
+        <% end %>
+        <%= f.input :sexo,
+          collection: Sip::Persona::SEXO_OPCIONES, 
+          label: 'Sexo:',
+          include_blank: '--Mostrar Todos',
           input_html: {
-            'data-enviarautomatico' => ''}
+            'data-enviarautomatico' => ''},
+          wrapper_html: { "style" => estdes }
          %>
       </div>
     </div>
@@ -85,8 +98,10 @@
         <%
           if params.nil? || params[:filtro].nil? || params[:filtro][:departamentos].nil?
             dep_sel = Sip::Departamento.habilitados.where(id_pais: 170).pluck(:id)
+            estdep = "display: block"
           else
             dep_sel = params[:filtro][:departamentos]
+            estdep = "display: none" if params[:filtro][:desagregar] == 'Departamento'
           end
         %>
         <%= f.input :departamentos,
@@ -98,7 +113,8 @@
             class: 'chosen-select',
             multiple: true,
             'data-enviarautomatico' => ''
-          }
+          },
+          wrapper_html: { 'style': estdep}
         %>
       </div>
     </div>
@@ -107,8 +123,10 @@
         <%
           if params.nil? || params[:filtro].nil? || params[:filtro][:categorias].nil?
             cat_sel = @vic_categorias
+            estcat = "display: block"
           else
             cat_sel = params[:filtro][:categorias]
+            estcat = "display: none" if params[:filtro][:desagregar] == 'Categoria'
           end
         %>
         <%= f.input :categorias,
@@ -118,13 +136,14 @@
             class: 'chosen-select',
             multiple: true,
             'data-enviarautomatico' => ''
-          }
+          },
+          wrapper_html: { 'style': estcat}
         %>
       </div>
     </div>
   </div>
   <div class="card-footer text-center">
-      <%= f.submit 'Filtrar' %>
+      <%= f.submit 'Cargar/Actualizar' %>
   </div>
 </div>
 <% end %>
@@ -136,6 +155,6 @@
 </br>
 <div class="row">
   <div class="col-12">
-    <%= column_chart(series_totsex, opciones_totsex) %>  
+    <%= column_chart(series_tot, opciones_tot) %>  
   </div>
 </div>

--- a/app/views/fil23_gen/graficar_apexcharts/victimizaciones_individuales.html.erb
+++ b/app/views/fil23_gen/graficar_apexcharts/victimizaciones_individuales.html.erb
@@ -1,14 +1,5 @@
 <h1> Graficar victimizaciones individuales </h1>
 <%
-  series_gen= [
-    {name: "Hombres",
-     data: @valores_m},
-    {name: "Mujeres",
-     data: @valores_f},
-    {name: "Sin sexo",
-     data: @valores_s}
-  ]
-
   opciones_gen = {
    title: 'Victimizaciones',
    xtitle: 'Fecha',
@@ -69,6 +60,24 @@
             "data-behaviour" => "datepicker",
             value: vff
           } %>
+      </div>
+      <div class="offset-sm-0 col-3">
+        <%= f.input :sexo,
+          collection: Sip::Persona::SEXO_OPCIONES, 
+          label: 'Sexo:',
+          include_blank: '--Mostrar Todos',
+          input_html: {
+            'data-enviarautomatico' => ''}
+         %>
+      </div>
+      <div class="offset-sm-0 col-3">
+        <%= f.input :desagregar,
+          collection: ['Sexo', 'Departamento', 'Categoria'], 
+          label: 'Desagregar por:',
+          selected: 'Categoria',
+          input_html: {
+            'data-enviarautomatico' => ''}
+         %>
       </div>
     </div>
     <div class="row">


### PR DESCRIPTION
Se permite desagregación por categoria y por departmento. funcional, aunque tarda unos 10 segundos en cargar por la cantidad de de datos y consulta (se piensa realizar mejoras)
Se simplifican funciones para consultar de manera más generica
Se soluciona flla degrafica (495)
Se oculta filtro al seleccionar la desagregación del mismo, en tanto en vista como en coffeescript (estilos)
Se eliminan labels sobre barras para que sólo quede la info al pasar el ratón por encima
Se cambia S, M y F de la grafica de totales por sus repectivos snombres completos
